### PR TITLE
chore(renovate): adopt shared python preset config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "extends": [
-    "config:recommended"
-  ],
-  "labels": [
-    "internal"
-  ],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
-  "semanticCommits": "enabled"
+  "extends": ["github>hasansezertasan/renovate-config:python"]
 }


### PR DESCRIPTION
## What

Replaces the inline Renovate config in `renovate.json` with the shared preset [`github>hasansezertasan/renovate-config:python`](https://github.com/hasansezertasan/renovate-config).

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>hasansezertasan/renovate-config:python"]
}
```

## Why

Centralizes Renovate configuration in one maintained preset so this repo inherits future improvements automatically, rather than duplicating settings inline.

## Behavior preserved

The preset is a **superset** of the previous inline config — nothing is lost:

| Setting | Before (inline) | After (via preset) |
| --- | --- | --- |
| `config:recommended` | ✅ | ✅ |
| `labels: ["internal"]` | ✅ | ✅ |
| `semanticCommits` | ✅ | ✅ |
| `dependencyDashboard` | ✅ | ✅ |
| `lockFileMaintenance` | enabled | enabled (scheduled before 4am Monday) |

## Added by the preset

- **`packageRules`** grouping dev/test/lint/docs dep-groups and non-major runtime updates to reduce PR noise.
- **Custom manager** for `rev` pins in `prek.toml` — relevant here since this repo uses `prek`, and Renovate's built-in pre-commit manager only reads `.pre-commit-config.yaml`.